### PR TITLE
[temporary] disable gui support

### DIFF
--- a/android/TerminalApp/java/com/android/system/virtualmachine/flags/Flags.kt
+++ b/android/TerminalApp/java/com/android/system/virtualmachine/flags/Flags.kt
@@ -1,0 +1,6 @@
+package com.android.system.virtualmachine.flags
+
+object Flags {
+    fun terminalGuiSupport(): Boolean = false
+    fun terminalStorageBalloon(): Boolean = false
+}


### PR DESCRIPTION
disable gui support as it leads to surfaceflinger until a solution is found.
also add terminalStorageBaloonSupport flag for passing compilation.